### PR TITLE
Remove BC naming support for new repository folders

### DIFF
--- a/src/LibraryInstaller.php
+++ b/src/LibraryInstaller.php
@@ -36,8 +36,6 @@ class LibraryInstaller extends BaseInstaller
         $bcMap = array(
             'clxmobilenet' => 'clxMobileNet',
             'clxmobilenetportable' => 'clxMobileNetPortable',
-            'clxbackendcms' => 'clxBackendCms',
-            'clxfrontendcms' => 'clxFrontendCms',
             'ebayman' => 'eBayMan',
             'mobisapi' => 'MobisApi',
         );


### PR DESCRIPTION
Backend and Frontend are new repos which can be installed without any BC compat restriction.